### PR TITLE
feat: publish OCI-based Helm chart to GHCR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - name: check source code
+      - name: Check source code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -23,8 +26,25 @@ jobs:
             exit 1
           fi
 
-      - uses: J12934/helm-gh-pages-action@master
+      # Publish chart to GitHub Pages
+      - name: Publish chart to GitHub Pages
+        uses: J12934/helm-gh-pages-action@master
         with:
           access-token: ${{ secrets.ACCESS_TOKEN }}
           charts-folder: "charts"
           deploy-branch: "gh-pages"
+
+      # Publish OCI-based chart to GitHub Container Registry
+      - name: Install Helm
+        uses: azure/setup-helm@v4.3.0
+        with:
+          version: v3.19.1
+
+      - name: Login to GHCR
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Package and publish chart to GHCR
+        run: |
+          helm package charts/tekton-pipeline
+          helm push tekton-pipeline-*.tgz oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ For latest set `app_version` to the latest tekton version from the [tekton relea
 [Helm](https://helm.sh) must be installed to use the charts.
 Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 
-Once Helm is set up properly, add the repo as follows:
+Once Helm is set up properly, you can install the chart using one of the following methods:
+
+#### Method 1: GitHub Pages Repository
+
+Add the repo as follows:
 
 ```bash
 helm repo add cdf https://cdfoundation.github.io/tekton-helm-chart/
@@ -55,6 +59,14 @@ you can then do
 
 ```bash
 helm search repo tekton
+```
+
+#### Method 2: GHCR OCI Registry
+
+The chart is also available as an OCI artifact in GitHub Container Registry:
+
+```bash
+helm install tekton-pipeline oci://ghcr.io/cdfoundation/charts/tekton-pipeline --version <version>
 ```
 
 The chart installs resources into the `tekton-pipelines` namespace


### PR DESCRIPTION
### Changes
* Publish the Helm chart to ghcr.io in addition to GitHub pages

### Context

Publishing OCI-based helm charts
